### PR TITLE
Add SONIX Gbg mention to rules

### DIFF
--- a/content/rules.md
+++ b/content/rules.md
@@ -4,9 +4,14 @@ description = "Member rules for access to the IX"
 keywords = ["rules"]
 +++
 
-Version: 1.1
+Version: 1.2
 
-By connecting to SONIX you acknowledge the following.
+The following rules are applicable to the following SONIX IXPs:
+
+ - SONIX Stockholm
+ - SONIX Gothenburg
+
+By connecting to an IXP part of SONIX you acknowledge the following.
 
 # General requirements
 


### PR DESCRIPTION

As per RIPE request:

> 2. Please provide a link to joining policy of SONIX Gothenburg. It should be clear from the web site that the policy is of SONIX Gothenburg IXP.