### PR TITLE
Handle member table fetch errors

### DIFF
--- a/static/members-table.js
+++ b/static/members-table.js
@@ -3,6 +3,14 @@ document.addEventListener('DOMContentLoaded', function() {
     addSearchFunctionality();
 });
 
+function displayFetchError() {
+    const container = document.getElementById('table-container');
+    if (container) {
+        container.innerHTML =
+            '<div class="alert alert-warning">Unable to load member list, please try again later</div>';
+    }
+}
+
 async function fetchDataAndCreateTable() {
     try {
         const response = await fetch('https://manager.sonix.network/api/v4/member-export/ixf/1.0');
@@ -15,9 +23,11 @@ async function fetchDataAndCreateTable() {
             createTable(data.member_list, data.ixp_list);
         } else {
             console.error('Required data not found in the response');
+            displayFetchError();
         }
     } catch (error) {
         console.error('Error:', error);
+        displayFetchError();
     }
 }
 


### PR DESCRIPTION
## Summary
- handle errors in the members table fetch
- show a placeholder when the data can't be fetched

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68839e223ce0832f9595d951410797ea