### PR TITLE
Tagline text wrap fix

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -592,6 +592,12 @@ section, div.section {
   max-width: 720px;
 }
 
+@media (min-width: 992px) {
+  .home-carousel .text-box {
+    max-width: 900px;
+  }
+}
+
 #footer {
   background: #333;
   color: #fff;


### PR DESCRIPTION
This fixes an additional text wrap after "Internet" in the tagline on desktop browser.